### PR TITLE
release 1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "influx-line"
-version = "1.0.0"
+version = "1.0.4"
 dependencies = [
  "chrono",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "influx-line"
-version = "1.0.0"
+version = "1.0.4"
 edition = "2024"
 authors = ["Invian"]
 license-file = "LICENSE"


### PR DESCRIPTION
the latest tag is 1.0.3 but since i was manually making tags, i simply 💀 forgor 💀 to bump it in `Cargo.toml`

i'll make a tag again after we merge this pr

for the future, we should probably automate it with a bot account for the organization. without it, github actions won't push to protected branches (so that's why i haven't added cargo release yet). let's leave it for later